### PR TITLE
Hotfix: Flatten `<compromisso>` inside `<titulopublico>` and improve `parse_decimal_value` handling

### DIFF
--- a/data_access.py
+++ b/data_access.py
@@ -3,7 +3,7 @@
 """
 Created on Wed Jan  8 17:39:16 2025
 
-@author: andrefelix
+@author: EN
 """
 
 

--- a/parse_xml_anbima.py
+++ b/parse_xml_anbima.py
@@ -112,7 +112,7 @@ def parse_files(str_file_name):
 
 def extract_node_data(root):
     """
-    Traverse the XML tree and extract structured data, 
+    Traverse the XML tree and extract structured data,
     including special handling for nested tags such as <compromisso> inside <titulopublico>.
 
     Args:
@@ -121,7 +121,7 @@ def extract_node_data(root):
     Returns:
         defaultdict: Dictionary mapping each tag to a list of extracted records.
     """
-    INLINE_CHILDREN = {
+    inline_hildren = {
         'titpublico': {'compromisso'},
     }
 
@@ -132,13 +132,13 @@ def extract_node_data(root):
             if len(child) == 0:
                 continue
 
-            if child.tag in INLINE_CHILDREN.get(parent.tag, set()):
+            if child.tag in inline_hildren.get(parent.tag, set()):
                 continue
 
             node_data = {}
 
             for subchild in child:
-                if subchild.tag in INLINE_CHILDREN.get(child.tag, set()):
+                if subchild.tag in inline_hildren.get(child.tag, set()):
                     for nested in subchild:
                         key = f"{subchild.tag}_{nested.tag}"
                         node_data[key] = parse_decimal_value(nested.text)

--- a/parse_xml_anbima.py
+++ b/parse_xml_anbima.py
@@ -32,7 +32,11 @@ def parse_decimal_value(value):
         float or str: Parsed monetary value as float if convertible, otherwise the original string.
     """
     if isinstance(value, str):
-        value = value.replace('R$', '').replace('$', '').replace(' ', '')
+        value = value.strip()
+        if not value:
+            return None
+
+        value = value.strip().replace('R$', '').replace('$', '').replace(' ', '')
 
         if re.match(r'^-?\d+?\.\d+$', value) or re.match(r'^\.\d+$', value):
             if value.startswith('.'):
@@ -109,7 +113,7 @@ def parse_files(str_file_name):
                 continue
             node_data = {}
             for subchild in child:
-                node_data[subchild.tag] = parse_decimal_value(subchild.text.strip() if subchild.text else None)
+                node_data[subchild.tag] = parse_decimal_value(subchild.text)
             data[child.tag].append(node_data)
 
     return data

--- a/parse_xml_anbima.py
+++ b/parse_xml_anbima.py
@@ -36,15 +36,15 @@ def parse_decimal_value(value):
         if not value:
             return None
 
-        value = value.replace('R$', '').replace('$', '').replace(' ', '')
+        vl_dec = value.replace('R$', '').replace('$', '').replace(' ', '')
 
-        if re.match(r'^-?\d+?\.\d+$', value) or re.match(r'^\.\d+$', value):
-            if value.startswith('.'):
-                value = '0' + value
-            elif value.startswith('-.'):
-                value = value.replace('-.', '-0.')
+        if re.match(r'^-?\d+?\.\d+$', vl_dec) or re.match(r'^\.\d+$', vl_dec):
+            if vl_dec.startswith('.'):
+                vl_dec = '0' + vl_dec
+            elif vl_dec.startswith('-.'):
+                vl_dec = vl_dec.replace('-.', '-0.')
 
-            return float(value)
+            return float(vl_dec)
 
     return value
 

--- a/parse_xml_anbima.py
+++ b/parse_xml_anbima.py
@@ -36,6 +36,9 @@ def parse_decimal_value(value):
         if not value:
             return None
 
+        if not any(c.isdigit() for c in value):
+            return value
+
         vl_dec = value.replace('R$', '').replace('$', '').replace(' ', '')
 
         if re.match(r'^-?\d+?\.\d+$', vl_dec) or re.match(r'^\.\d+$', vl_dec):

--- a/parse_xml_anbima.py
+++ b/parse_xml_anbima.py
@@ -107,13 +107,37 @@ def parse_files(str_file_name):
         print(f"{str_file_name} is missing a 'header' node.")
         raise ValueError('header not found')
 
+    return extract_node_data(root)
+
+
+def extract_node_data(root):
+    """
+    Traverse the XML tree and extract structured data, 
+    including special handling for nested tags such as <compromisso> inside <titulopublico>.
+
+    Args:
+        root (Element): Root element of the parsed XML.
+
+    Returns:
+        defaultdict: Dictionary mapping each tag to a list of extracted records.
+    """
+    data = defaultdict(list)
+
     for fund in root.findall(".//*"):
         for child in fund:
             if len(child) == 0:
                 continue
+
             node_data = {}
+
             for subchild in child:
-                node_data[subchild.tag] = parse_decimal_value(subchild.text)
+                if child.tag == 'titpublico' and subchild.tag == 'compromisso':
+                    for compromisso_child in subchild:
+                        key = f"compromisso_{compromisso_child.tag}"
+                        node_data[key] = parse_decimal_value(compromisso_child.text)
+                else:
+                    node_data[subchild.tag] = parse_decimal_value(subchild.text)
+
             data[child.tag].append(node_data)
 
     return data

--- a/parse_xml_anbima.py
+++ b/parse_xml_anbima.py
@@ -36,7 +36,7 @@ def parse_decimal_value(value):
         if not value:
             return None
 
-        value = value.strip().replace('R$', '').replace('$', '').replace(' ', '')
+        value = value.replace('R$', '').replace('$', '').replace(' ', '')
 
         if re.match(r'^-?\d+?\.\d+$', value) or re.match(r'^\.\d+$', value):
             if value.startswith('.'):

--- a/parse_xml_anbima.py
+++ b/parse_xml_anbima.py
@@ -121,20 +121,27 @@ def extract_node_data(root):
     Returns:
         defaultdict: Dictionary mapping each tag to a list of extracted records.
     """
+    INLINE_CHILDREN = {
+        'titpublico': {'compromisso'},
+    }
+
     data = defaultdict(list)
 
-    for fund in root.findall(".//*"):
-        for child in fund:
+    for parent in root.findall(".//*"):
+        for child in parent:
             if len(child) == 0:
+                continue
+
+            if child.tag in INLINE_CHILDREN.get(parent.tag, set()):
                 continue
 
             node_data = {}
 
             for subchild in child:
-                if child.tag == 'titpublico' and subchild.tag == 'compromisso':
-                    for compromisso_child in subchild:
-                        key = f"compromisso_{compromisso_child.tag}"
-                        node_data[key] = parse_decimal_value(compromisso_child.text)
+                if subchild.tag in INLINE_CHILDREN.get(child.tag, set()):
+                    for nested in subchild:
+                        key = f"{subchild.tag}_{nested.tag}"
+                        node_data[key] = parse_decimal_value(nested.text)
                 else:
                     node_data[subchild.tag] = parse_decimal_value(subchild.text)
 

--- a/sys_data/harmonization_values_rules.json
+++ b/sys_data/harmonization_values_rules.json
@@ -1,16 +1,20 @@
 {
-    "CREDEB": {
+    "TODAS": {
+        "filters": [],
+        "formula": [
+            "valorfindisp",
+            "valorfinemgar",
+            "valor"
+        ]
+    },
+    "CAP": {
         "filters": [
             {
-                "column": "credeb",
-                "value": "D"
+                "column": "tipo",
+                "value": "valorpagar"
             }
         ],
         "formula": "valor * -1"
-    },
-    "TODAS": {
-        "filters": [],
-        "formula": ["valor"]
     },
     "CAIXA": {
         "filters": [
@@ -52,7 +56,7 @@
         "filters": [
             {
                 "column": "tipo",
-                "value": "OPCOESACOES"
+                "value": "opcoesacoes"
             }
         ],
         "formula": "valorfinanceiro"
@@ -61,7 +65,7 @@
         "filters": [
             {
                 "column": "tipo",
-                "value": "OPCOESDERIV"
+                "value": "opcoesderiv"
             }
         ],
         "formula": "valorfinanceiro"
@@ -70,7 +74,7 @@
         "filters": [
             {
                 "column": "tipo",
-                "value":"ACOES"
+                "value": "acoes"
             },
             {
                 "column": "classeoperacao",
@@ -83,7 +87,7 @@
         "filters": [
             {
                 "column": "tipo",
-                "value":"ACOES"
+                "value": "acoes"
             },
             {
                 "column": "classeoperacao",
@@ -92,23 +96,14 @@
         ],
         "formula": "valorfinemgar"
     },
-    "CAP": {
+    "EMPRESTIMO": {
         "filters": [
             {
                 "column": "tipo",
-                "value": "cap"
+                "value": "operpart"
             }
         ],
-        "formula": "new_valor * -1"
-    },
-    "EMPRESTIMO": {
-        "filters":  [
-            {
-                "column": "tipo",
-                "value": "emprestimos"
-            }
-        ],
-        "formula": "vlavencer + vlvencido - ( (vlavencer + vlvencido) * percprovcred / 100.0 )"
+        "formula": " vlavencer + vlvencido - ( (vlavencer + vlvencido) * percprovcred/100 )"
     },
     "IMOVEIS": {
         "filters": [

--- a/sys_data/header_daily_values.json
+++ b/sys_data/header_daily_values.json
@@ -1,25 +1,29 @@
 {
     "valorcota": {
+        "serie": true
     },
     "quantidade": {
+        "serie": true
     },
     "patliq": {
-        "allocation": true
+        "serie": true
     },
     "valorativos": {
-        "allocation": true
+        "serie": true
     },
     "valorreceber": {
-        "allocation": true
+        "serie": false
     },
     "valorpagar": {
-        "allocation": true
+        "serie": false
     },
     "vlcotasemitir": {
+        "serie": true
     },
     "vlcotasresgatar": {
+        "serie": true
     },
     "tributos": {
-        "allocation": true
+        "serie": false
     }
 }

--- a/sys_data/types_to_exclude.json
+++ b/sys_data/types_to_exclude.json
@@ -1,1 +1,1 @@
-["despesas", "outrasdespesas", "provisao"]
+["despesas", "outrasdespesas", "provisao", "valorativos", "tributos"]


### PR DESCRIPTION
### Summary of changes:

* **`<titulopublico>` parsing**: When the `<compromisso>` subtag is present, its child elements are now parsed into columns (prefixed with `compromisso_`) instead of generating separate rows.
* **`parse_decimal_value` refactor**: Now applies `strip()` and returns `None` for empty or whitespace-only strings, allowing direct use of `.text` values without conditional checks.

### Motivation:

This urgent fix addresses data normalization issues by ensuring `<compromisso>` values are correctly integrated into the parent record structure. It also reduces repetitive code and improves robustness when handling optional or empty XML elements.