### PR TITLE
Refactor equity stake logic to reuse investor_holdings and expose unmatched entries

### DIFF
--- a/investment_tree.py
+++ b/investment_tree.py
@@ -278,7 +278,7 @@ def main():
     utl.log_message('Fim processamento árvore.')
 
     utl.log_message('Salvando dados')
-    file_name = f"{xlsx_destination_path}/arvore_carteiras"
+    file_name = f"{xlsx_destination_path}arvore_carteiras"
     fhdl.save_df(tree_horzt, file_name, 'xlsx')
     utl.log_message(f"Fim processamento árvore. Arquivo {file_name}.{file_ext}")
 


### PR DESCRIPTION
This PR refactors the computation of equity stake by isolating investor holdings (`investor_holdings`) in the orchestration layer and reusing it across multiple functions.

Key changes:
- Created `investor_holdings` in `main()` to avoid column duplication and maintain consistency.
- Updated `compute_equity_stake()` to receive prefiltered holdings as input.
- Added logic to compute `unmatched_idx` (investor entries not matched to invested funds) via index difference.
- Enables external inspection of unmatched entries for debugging or audit purposes.

These changes improve code clarity, support SRP, and facilitate downstream error handling.
