### PR TITLE
Refactor governance structure attribution logic

### DIFF
--- a/clean_and_prepare_raw_data.py
+++ b/clean_and_prepare_raw_data.py
@@ -66,7 +66,7 @@ def harmonize_values(dtfr, harmonization_rules):
     1   cotas    200  180.0
     2   caixa    300  330.0
     """
-    dtfr['valor_calc'] = None
+    dtfr['valor_calc'] = 0.0
 
     for key, value in harmonization_rules.items():
         try:

--- a/compute_metrics.py
+++ b/compute_metrics.py
@@ -56,7 +56,7 @@ def compute_equity_stake(investor_holdings, invested):
 
     Args:
         investor_holdings (pd.DataFrame): DataFrame containing investor positions,
-            with required columns: 'cnpjfundo', 'qtdisponivel', and 'dtposicao'.
+            with required columns: 'cnpjfundo', 'valor_calc', and 'dtposicao'.
         invested (pd.DataFrame): DataFrame containing fund value data,
             with required columns: 'cnpj', 'valor', 'dtposicao' and a 'tipo' column
             (must be equal to 'quantidade' for inclusion).
@@ -70,7 +70,7 @@ def compute_equity_stake(investor_holdings, invested):
     columns_invested = ['cnpj', 'valor', 'dtposicao']
 
     equity_stake = investor_holdings.merge(
-        invested[invested['tipo'] == 'quantidade'][columns_invested],
+        invested[invested['tipo'] == 'patliq'][columns_invested],
         left_on=['cnpjfundo', 'dtposicao'],
         right_on=['cnpj', 'dtposicao'],
         how='inner'
@@ -78,7 +78,7 @@ def compute_equity_stake(investor_holdings, invested):
 
     equity_stake.set_index('original_index', inplace=True)
 
-    equity_stake['equity_stake'] = equity_stake['qtdisponivel'] / equity_stake['valor']
+    equity_stake['equity_stake'] = equity_stake['valor_calc'] / equity_stake['valor']
 
     return equity_stake
 
@@ -91,7 +91,7 @@ def compute(entity, invested, types_series, composition_group_keys):
     - Computes equity stake
     - Saves processed data back to Excel files.
     """
-    investor_holdings_cols = ['cnpjfundo', 'qtdisponivel', 'dtposicao']
+    investor_holdings_cols = ['cnpjfundo', 'valor_calc', 'dtposicao']
 
     investor_holdings = entity[entity['cnpjfundo'].notnull()][investor_holdings_cols].copy()
 

--- a/investment_tree/__init__.py
+++ b/investment_tree/__init__.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on Sat Jun  7 13:58:15 2025
+
+@author: andrefelix
+"""
+
+
+from .builder import build_tree
+from .enrichment import enrich_tree

--- a/investment_tree/builder.py
+++ b/investment_tree/builder.py
@@ -29,17 +29,6 @@ def _apply_calculations_to_new_rows(current, mask, deep):
     current.loc[mask, 'composicao'] *= current.loc[mask, f"composicao_nivel_{deep+1}"].fillna(1)
     current.loc[mask, 'isin'] = current.loc[mask, f"isin_nivel_{deep+1}"]
 
-    mask_estrutura = mask & current[f"IS_CNPJFUNDO_ESTRUTURA_GERENCIAL_nivel_{deep+1}"]
-
-    current.loc[mask_estrutura, 'KEY_ESTRUTURA_GERENCIAL'] = current.loc[
-        mask_estrutura,
-        f"cnpj_nivel_{deep+1}"
-    ]
-    current.loc[mask_estrutura, 'NEW_TIPO_ESTRUTURA_GERENCIAL'] = current.loc[
-        mask_estrutura,
-        f"NEW_TIPO_nivel_{deep+1}"
-    ]
-
     sufix = '' if deep == 0 else f"_nivel_{deep}"
     current.loc[mask, 'PARENT_FUNDO'] = current.loc[mask, f"NEW_NOME_ATIVO{sufix}"]
     current.loc[mask, 'PARENT_FUNDO_GESTOR'] = current.loc[mask, f"NEW_GESTOR{sufix}"]
@@ -171,145 +160,7 @@ def build_tree_leaves(tree_branchs, funds):
     return leaves[tree_branchs.columns]
 
 
-def create_column_based_on_levels(tree_hrzt, new_col, base_col, deep):
-    """
-    Preenche uma nova coluna com valores prioritários entre colunas base e níveis sucessivos.
-
-    Args:
-        tree_hrzt (pd.DataFrame): DataFrame de entrada.
-        new_col (str): Nome da nova coluna a ser criada.
-        base_col (str): Nome da coluna base.
-        deep (int): Número de níveis (sufixos _nivel_1 a _nivel_{deep}).
-
-    Returns:
-        pd.DataFrame: O DataFrame com a nova coluna preenchida.
-    """
-    priority_cols = [f"{base_col}_nivel_{i}" for i in range(deep, 0, -1)]
-    priority_cols.append(base_col)
-
-    tree_hrzt[new_col] = tree_hrzt[priority_cols].bfill(axis=1).iloc[:, 0]
-
-
-def fill_level_columns_forward(tree_hrzt, base_col, deep):
-    """
-    Forward-fills missing values in level columns by cascading values from higher to lower levels.
-
-    Args:
-        tree_hrzt (pd.DataFrame): The DataFrame with hierarchical level columns.
-        base_col (str): Base name of the columns (e.g., 'estrutura').
-        deep (int): Number of levels (e.g., 4 means columns from _nivel_1 to _nivel_4).
-
-    Returns:
-        pd.DataFrame: The modified DataFrame with levels filled hierarchically.
-    """
-    for i in range(0, deep):
-        curr_level_suffix = f"_nivel_{i}" if i > 0 else ''
-        current_col = f"{base_col}{curr_level_suffix}"
-        next_col = f"{base_col}_nivel_{i+1}"
-
-        mask = tree_hrzt[next_col].isna() | (tree_hrzt[next_col] == '')
-        tree_hrzt.loc[mask, next_col] = tree_hrzt.loc[mask, current_col]
-
-
-def generate_final_columns(tree_horzt):
-    """
-    Generate final columns based on hierarchical levels in the 'tree_horzt' DataFrame.
-
-    This function calculates the maximum depth of the hierarchy using the 'nivel' column
-    and uses it to generate final versions of multiple columns by aggregating or selecting
-    values based on that depth.
-
-    Parameters:
-    ----------
-    tree_horzt : pandas.DataFrame
-        The hierarchical tree DataFrame containing the 'nivel' column and intermediate
-        columns used to compute final columns.
-
-    Returns:
-    -------
-    None
-        The function modifies the input DataFrame in place, adding new final columns.
-    """
-    max_deep = tree_horzt['nivel'].max()
-
-    columns_to_generate = [
-        'NEW_TIPO', 'NEW_NOME_ATIVO', 'NEW_GESTOR_WORD_CLOUD', 'fEMISSOR.NOME_EMISSOR'
-    ]
-
-    for base_col in columns_to_generate:
-        create_column_based_on_levels(tree_horzt, f"{base_col}_FINAL", base_col, max_deep)
-
-
-def fill_missing_estrutura_gerencial(tree_horzt, key_veiculo_estrutura_gerencial):
-    """
-    Fills missing values in the 'KEY_ESTRUTURA_GERENCIAL' column based on whether
-    the corresponding 'codcart' value exists in a reference list of valid keys.
-
-    Only rows where 'KEY_ESTRUTURA_GERENCIAL' is null or an empty string are modified.
-
-    Rules:
-        - If 'codcart' is in 'key_veiculo_estrutura_gerencial', assign 'codcart'
-        - Otherwise, assign '#OUTROS'
-
-    Parameters:
-        tree_horzt (pd.DataFrame): DataFrame containing the columns:
-            - 'KEY_ESTRUTURA_GERENCIAL'
-            - 'codcart'
-
-        key_veiculo_estrutura_gerencial (Iterable): List or set of valid 'codcart' keys.
-
-    Returns:
-        None: Modifies the DataFrame in place.
-    """
-    sem_estrutura = (
-        tree_horzt['KEY_ESTRUTURA_GERENCIAL'].isna() |
-        (tree_horzt['KEY_ESTRUTURA_GERENCIAL'] == '')
-    )
-
-    codcart = tree_horzt['codcart'].isin(key_veiculo_estrutura_gerencial)
-
-    tree_horzt.loc[sem_estrutura & codcart, 'KEY_ESTRUTURA_GERENCIAL'] = \
-        tree_horzt.loc[sem_estrutura & codcart, 'codcart']
-
-    tree_horzt.loc[sem_estrutura & ~codcart, 'KEY_ESTRUTURA_GERENCIAL'] = '#OUTROS'
-
-
-def enrich_tree(tree_horzt, governance_struct):
-    """
-    Enriches a tree structure with derived textual fields and governance structure mappings.
-
-    This function:
-        - Generates final label columns.
-        - Propagates level-based data forward.
-        - Creates a combined search string from relevant textual fields.
-        - Attempts to fill in missing governance structure information.
-
-    Args:
-        tree_horzt (pd.DataFrame): The horizontal tree structure containing fund
-        relationships.
-        governance_struct (pd.DataFrame): Governance structure dataset with
-        'KEY_VEICULO' identifiers.
-
-    Returns:
-        None: The input DataFrame is modified in-place.
-    """
-    key_vehicle_governance_struct = governance_struct['KEY_VEICULO'].dropna().unique()
-
-    generate_final_columns(tree_horzt)
-    max_deep = tree_horzt['nivel'].max()
-    fill_level_columns_forward(tree_horzt, 'NEW_NOME_ATIVO', max_deep)
-
-    tree_horzt['SEARCH'] = (
-        tree_horzt['NEW_NOME_ATIVO_FINAL'].fillna('')
-        + ' ' + tree_horzt['NEW_GESTOR_WORD_CLOUD_FINAL'].fillna('')
-        + ' ' + tree_horzt['fEMISSOR.NOME_EMISSOR_FINAL'].fillna('')
-        + ' ' + tree_horzt['PARENT_FUNDO'].fillna('')
-    )
-
-    fill_missing_estrutura_gerencial(tree_horzt, key_vehicle_governance_struct)
-
-
-def build_tree(funds, portfolios, governance_struct):
+def build_tree(funds, portfolios):
     """
     Builds a horizontal tree of fund relationships by combining fund and portfolio data.
 
@@ -323,21 +174,14 @@ def build_tree(funds, portfolios, governance_struct):
         funds (pd.DataFrame): DataFrame containing fund-to-fund relationships.
         portfolios (pd.DataFrame): DataFrame containing investor portfolios and
         allocations.
-        governance_struct (pd.DataFrame): Governance structure dataset with
-        'KEY_VEICULO' identifiers.
 
     Returns:
         pd.DataFrame: A combined DataFrame representing the horizontal fund tree.
     """
-    key_vehicle_governance_struct = governance_struct['KEY_VEICULO'].dropna().unique()
-
     cols_funds = ['cnpj', 'dtposicao', 'cnpjfundo', 'equity_stake', 'composicao',
                   'valor_calc', 'isin', 'NEW_TIPO', 'fNUMERACA.DESCRICAO',
                   'fEMISSOR.NOME_EMISSOR', 'NEW_NOME_ATIVO', 'NEW_GESTOR',
-                  'NEW_GESTOR_WORD_CLOUD', 'IS_CNPJFUNDO_ESTRUTURA_GERENCIAL']
-
-    funds['IS_CNPJFUNDO_ESTRUTURA_GERENCIAL'] = funds['cnpj'].isin(key_vehicle_governance_struct)
-    funds['NEW_TIPO_ESTRUTURA_GERENCIAL'] = funds['NEW_TIPO']
+                  'NEW_GESTOR_WORD_CLOUD']
 
     funds = funds[funds['valor_serie'] == 0][cols_funds].copy()
 
@@ -352,14 +196,5 @@ def build_tree(funds, portfolios, governance_struct):
     portfolios['nivel'] = 0
     portfolios['fNUMERACA.DESCRICAO'] = ''
     portfolios['cnpj'] = ''
-    portfolios['NEW_TIPO_ESTRUTURA_GERENCIAL'] = portfolios['NEW_TIPO']
-
-    mask_estrutura = portfolios['cnpjfundo'].isin(key_vehicle_governance_struct)
-    portfolios['IS_CNPJFUNDO_ESTRUTURA_GERENCIAL'] = portfolios['cnpjfundo'].isin(
-        key_vehicle_governance_struct
-    )
-    portfolios.loc[mask_estrutura, 'KEY_ESTRUTURA_GERENCIAL'] = (
-        portfolios.loc[mask_estrutura, 'cnpjfundo']
-    )
 
     return build_tree_horizontal(portfolios.copy(), funds)

--- a/investment_tree/enrichment.py
+++ b/investment_tree/enrichment.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on Sat Jun  7 12:58:01 2025
+
+@author: andrefelix
+"""
+
+
+def generate_final_columns(tree_horzt):
+    """
+    Generate final columns based on hierarchical levels in the 'tree_horzt' DataFrame.
+
+    This function calculates the maximum depth of the hierarchy using the 'nivel' column
+    and uses it to generate final versions of multiple columns by aggregating or selecting
+    values based on that depth.
+
+    Parameters:
+    ----------
+    tree_horzt : pandas.DataFrame
+        The hierarchical tree DataFrame containing the 'nivel' column and intermediate
+        columns used to compute final columns.
+
+    Returns:
+    -------
+    None
+        The function modifies the input DataFrame in place, adding new final columns.
+    """
+    max_deep = tree_horzt['nivel'].max()
+
+    columns_to_generate = [
+        'NEW_TIPO', 'NEW_NOME_ATIVO', 'NEW_GESTOR_WORD_CLOUD', 'fEMISSOR.NOME_EMISSOR'
+    ]
+
+    for base_col in columns_to_generate:
+        create_column_based_on_levels(tree_horzt, f"{base_col}_FINAL", base_col, max_deep)
+
+
+def create_column_based_on_levels(tree_hrzt, new_col, base_col, deep):
+    """
+    Preenche uma nova coluna com valores prioritários entre colunas base e níveis sucessivos.
+
+    Args:
+        tree_hrzt (pd.DataFrame): DataFrame de entrada.
+        new_col (str): Nome da nova coluna a ser criada.
+        base_col (str): Nome da coluna base.
+        deep (int): Número de níveis (sufixos _nivel_1 a _nivel_{deep}).
+
+    Returns:
+        pd.DataFrame: O DataFrame com a nova coluna preenchida.
+    """
+    priority_cols = [f"{base_col}_nivel_{i}" for i in range(deep, 0, -1)]
+    priority_cols.append(base_col)
+
+    tree_hrzt[new_col] = tree_hrzt[priority_cols].bfill(axis=1).iloc[:, 0]
+
+
+def fill_level_columns_forward(tree_hrzt, base_col, deep):
+    """
+    Forward-fills missing values in level columns by cascading values from higher to lower levels.
+
+    Args:
+        tree_hrzt (pd.DataFrame): The DataFrame with hierarchical level columns.
+        base_col (str): Base name of the columns (e.g., 'estrutura').
+        deep (int): Number of levels (e.g., 4 means columns from _nivel_1 to _nivel_4).
+
+    Returns:
+        pd.DataFrame: The modified DataFrame with levels filled hierarchically.
+    """
+    for i in range(0, deep):
+        curr_level_suffix = f"_nivel_{i}" if i > 0 else ''
+        current_col = f"{base_col}{curr_level_suffix}"
+        next_col = f"{base_col}_nivel_{i+1}"
+
+        mask = tree_hrzt[next_col].isna() | (tree_hrzt[next_col] == '')
+        tree_hrzt.loc[mask, next_col] = tree_hrzt.loc[mask, current_col]
+
+
+def enrich_tree(tree_horzt):
+    """
+    Enriches a tree structure with derived textual fields and governance structure mappings.
+
+    This function:
+        - Generates final label columns.
+        - Propagates level-based data forward.
+        - Creates a combined search string from relevant textual fields.
+        - Attempts to fill in missing governance structure information.
+
+    Args:
+        tree_horzt (pd.DataFrame): The horizontal tree structure containing fund
+        relationships.
+
+    Returns:
+        None: The input DataFrame is modified in-place.
+    """
+    generate_final_columns(tree_horzt)
+    max_deep = tree_horzt['nivel'].max()
+    fill_level_columns_forward(tree_horzt, 'NEW_NOME_ATIVO', max_deep)
+
+    tree_horzt['SEARCH'] = (
+        tree_horzt['NEW_NOME_ATIVO_FINAL'].fillna('')
+        + ' ' + tree_horzt['NEW_GESTOR_WORD_CLOUD_FINAL'].fillna('')
+        + ' ' + tree_horzt['fEMISSOR.NOME_EMISSOR_FINAL'].fillna('')
+        + ' ' + tree_horzt['PARENT_FUNDO'].fillna('')
+    )

--- a/reporting/__init__.py
+++ b/reporting/__init__.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on Sat Jun  7 14:46:57 2025
+
+@author: andrefelix
+"""
+
+
+from .governance_struct import assign_governance_struct_keys
+
+__all__ = ["assign_governance_struct_keys"]

--- a/reporting/governance_struct.py
+++ b/reporting/governance_struct.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on Sat Jun  7 13:50:35 2025
+
+@author: andrefelix
+"""
+
+
+def fill_missing_governance_struct(tree_horzt, key_vehicle_governance_struct):
+    """
+    Fills missing values in the 'KEY_ESTRUTURA_GERENCIAL' column based on whether
+    the corresponding 'codcart' value exists in a reference list of valid keys.
+
+    Only rows where 'KEY_ESTRUTURA_GERENCIAL' is null or an empty string are modified.
+
+    Rules:
+        - If 'codcart' is in 'key_vehicle_governance_struct', assign 'codcart'
+        - Otherwise, assign '#OUTROS'
+
+    Parameters:
+        tree_horzt (pd.DataFrame): DataFrame containing the columns:
+            - 'KEY_ESTRUTURA_GERENCIAL'
+            - 'codcart'
+
+        key_vehicle_governance_struct (Iterable): List or set of valid 'codcart' keys.
+
+    Returns:
+        None: Modifies the DataFrame in place.
+    """
+    missing_struct = (
+        tree_horzt['KEY_ESTRUTURA_GERENCIAL'].isna() |
+        (tree_horzt['KEY_ESTRUTURA_GERENCIAL'] == '')
+    )
+
+    codcart = tree_horzt['codcart'].isin(key_vehicle_governance_struct)
+
+    tree_horzt.loc[missing_struct & codcart, 'KEY_ESTRUTURA_GERENCIAL'] = \
+        tree_horzt.loc[missing_struct & codcart, 'codcart']
+
+    tree_horzt.loc[missing_struct & ~codcart, 'KEY_ESTRUTURA_GERENCIAL'] = '#OUTROS'
+
+
+def assign_estrutura_gerencial_key(tree, key_vehicle_governance_struct, max_deep):
+    """
+    Atribui as colunas 'KEY_ESTRUTURA_GERENCIAL' e 'NEW_TIPO_ESTRUTURA_GERENCIAL' com base
+    no primeiro nível (do mais profundo ao mais superficial) em que o CNPJ do fundo investidor
+    ('cnpjfundo_nivel_{i}') pertence à estrutura gerencial.
+
+    Args:
+        tree (pd.DataFrame): DataFrame da árvore horizontal.
+        key_vehicle_governance_struct (Iterable): Conjunto de CNPJs da estrutura gerencial.
+        max_deep (int): Profundidade máxima da árvore.
+
+    Returns:
+        None: Modifica o DataFrame in-place.
+    """
+    tree['KEY_ESTRUTURA_GERENCIAL'] = None
+    tree['NEW_TIPO_ESTRUTURA_GERENCIAL'] = None
+
+    for i in range(max_deep, -1, -1):
+        cnpj_col = 'cnpjfundo' if i == 0 else f'cnpjfundo_nivel_{i}'
+        tipo_col = 'NEW_TIPO' if i == 0 else f'NEW_TIPO_nivel_{i}'
+
+        mask_key_missing = tree['KEY_ESTRUTURA_GERENCIAL'].isna()
+        mask_in_estrutura = tree[cnpj_col].isin(key_vehicle_governance_struct)
+        mask = mask_key_missing & mask_in_estrutura
+
+        tree.loc[mask, 'KEY_ESTRUTURA_GERENCIAL'] = tree.loc[mask, cnpj_col]
+        tree.loc[mask, 'NEW_TIPO_ESTRUTURA_GERENCIAL'] = tree.loc[mask, tipo_col]
+
+
+def assign_governance_struct_keys(tree_horzt, governance_struct):
+    """
+    Assigns governance structure keys to the investment tree based on fund identifiers.
+
+    This function enriches the investment tree with governance structure information by:
+        - Scanning all hierarchical levels to identify the first occurrence of a fund
+          (cnpjfundo_nivel_{i}) present in the governance structure list and assigning it
+          to 'KEY_ESTRUTURA_GERENCIAL' and 'NEW_TIPO_ESTRUTURA_GERENCIAL'.
+        - Filling in any remaining missing values in 'KEY_ESTRUTURA_GERENCIAL' based on
+          whether the 'codcart' field exists in the governance structure list.
+          If not, '#OUTROS' is assigned as a fallback.
+
+    Parameters:
+        tree_horzt (pd.DataFrame): The horizontal investment tree containing fund relationships
+            and hierarchical depth.
+        governance_struct (pd.DataFrame): A DataFrame containing governance structure
+            definitions, including the column 'KEY_VEICULO'.
+
+    Returns:
+        None: The function modifies the input DataFrame in place.
+    """
+    key_vehicle_governance_struct = governance_struct['KEY_VEICULO'].dropna().unique()
+
+    max_deep = tree_horzt['nivel'].max()
+
+    assign_estrutura_gerencial_key(tree_horzt, key_vehicle_governance_struct, max_deep)
+
+    fill_missing_governance_struct(tree_horzt, key_vehicle_governance_struct)


### PR DESCRIPTION
Closes #22 

#### Summary

This PR refactors and consolidates the governance structure attribution logic applied to the investment tree. It introduces a clearer separation of concerns and improves rule enforcement for identifying governance-linked funds.

#### Key Changes

* **Refactored** `assign_estrutura_gerencial_info` to:

  * Traverse the tree from the deepest level to the base (`cnpjfundo`)
  * Assign `KEY_ESTRUTURA_GERENCIAL` only if the fund belongs to the governance structure and `NEW_TIPO` is not `'COTAS'`
  * Apply a fallback rule for unmatched records with filled `cnpjfundo`, assigning `'#OUTROS'`

* **Removed** the `NEW_TIPO_ESTRUTURA_GERENCIAL` column:

  * It was generated but never used downstream
  * Its presence created confusion about its semantic purpose

* **Improved modularization**:

  * Governance logic is now encapsulated in a dedicated module
  * General enrichment logic remains in `investment_tree_enrichment.py`

#### Motivation

* Avoid mislabeling `COTAS`-type funds as governance-linked
* Prevent propagation of unused or misleading metadata
* Establish a cleaner, domain-aligned pipeline for governance attribution
