### PR TITLE
feat(submassa): forward fill do pct de rateio entre datas de posição

### DIFF
--- a/carteiras_operations.py
+++ b/carteiras_operations.py
@@ -109,3 +109,99 @@ def integrate_allocated_partplanprev(entity, allocated_partplanprev):
     entity['valor_calc'] = entity['valor_calc'].where(entity['flag_rateio'] != 1, 0)
 
     return entity
+
+
+def extract_portfolio_submassa(cad_submassa, portfolios):
+    """
+    Splits the portfolios DataFrame between rows that belong to a 'submassa'
+    (according to ``cad_submassa['CODCART']``) and the remaining rows, and
+    enriches the submassa subset with the registry columns from cad_submassa.
+
+    Parameters
+    ----------
+    cad_submassa : pandas.DataFrame
+        Registry of submassas. Must contain at least 'CODCART'.
+    portfolios : pandas.DataFrame
+        Portfolios DataFrame. Must contain 'codcart'.
+
+    Returns
+    -------
+    list[pandas.DataFrame]
+        ``[portfolios_without_submassa, port_submassa]`` where
+        ``port_submassa`` is the submassa-tagged subset enriched with the
+        cad_submassa columns.
+    """
+    mask = portfolios['codcart'].isin(cad_submassa['CODCART'])
+
+    port_submassa = portfolios.loc[mask].merge(
+        cad_submassa,
+        left_on='codcart',
+        right_on='CODCART',
+        how='left',
+    )
+
+    return [portfolios.loc[~mask], port_submassa]
+
+
+def compute_composition_portfolio_submassa(port_submassa):
+    """
+    Adds composition columns to ``port_submassa`` in-place:
+
+    - ``total_submassa_isin_cnpb``: sum of ``valor_calc`` per
+      (``dtposicao``, ``CNPB``, ``isin``).
+    - ``pct_submassa_isin_cnpb``: ratio of the row's ``valor_calc`` to the
+      group total.
+
+    Parameters
+    ----------
+    port_submassa : pandas.DataFrame
+        Submassa-tagged portfolios DataFrame, already enriched with the
+        cad_submassa registry columns.
+    """
+    port_submassa['total_submassa_isin_cnpb'] = (
+        port_submassa.groupby(['dtposicao', 'CNPB', 'isin'])['valor_calc'].transform('sum')
+    )
+
+    port_submassa['pct_submassa_isin_cnpb'] = (
+        port_submassa['valor_calc'] / port_submassa['total_submassa_isin_cnpb']
+    )
+
+
+def forward_fill_submassa_pct(port_submassa: pd.DataFrame,
+                              portfolios: pd.DataFrame) -> pd.DataFrame:
+    """
+    Expands ``port_submassa`` to every ``(CNPB, dtposicao)`` observed in
+    ``portfolios``, then forward-fills all non-key columns within each
+    ``(CNPB, isin, CODCART, COD_SUBMASSA)`` group (ordered by ``dtposicao``).
+    Dates before the first real observation for a group stay NaN.
+    """
+    group_cols = ['CNPB', 'isin', 'CODCART', 'COD_SUBMASSA']
+
+    if port_submassa.empty:
+        return port_submassa.copy()
+
+    calendar = (
+        portfolios[['cnpb', 'dtposicao']]
+        .dropna(subset=['cnpb'])
+        .drop_duplicates()
+        .rename(columns={'cnpb': 'CNPB'})
+    )
+
+    keys = port_submassa[group_cols].drop_duplicates()
+    skeleton = keys.merge(calendar, on='CNPB', how='inner')
+
+    result = skeleton.merge(
+        port_submassa,
+        on=group_cols + ['dtposicao'],
+        how='left',
+    )
+
+    result = result.sort_values(group_cols + ['dtposicao'])
+
+    cols_to_ffill = ['pct_submassa_isin_cnpb']
+    if cols_to_ffill:
+        result[cols_to_ffill] = (
+            result.groupby(group_cols, sort=False)[cols_to_ffill].ffill()
+        )
+
+    return result.reset_index(drop=True)

--- a/config.ini.master
+++ b/config.ini.master
@@ -1,0 +1,16 @@
+[Paths]
+;destination_file_extension = csv
+destination_file_extension = parquet
+xml_source_path = C:\Work\Vivest\API\Dataset\xmlAnbima\sta\data
+xlsx_destination_path = C:\Work\Vivest\API\Dataset\xmlAnbima\sta 
+xlsx_aux_path = C:\Work\Vivest\API\Dataset\xmlAnbima\sta
+data_aux_path = C:\Work\Vivest\API\Dataset\dbAux
+logs = C:\Work\Vivest\API\Dataset\xmlAnbima\sta\log
+mec_sac_path = C:\Work\Vivest\API\Dataset\mecSAC\_
+custodia_source_path = C:\Work\Vivest\API\Dataset\custodia
+custodia_destin_path = C:\Work\Vivest\API\Dataset\custodia\_
+performance_path = C:\Work\Vivest\API\Dataset\baseRentabilidade\resumoDesempenho
+
+[Debug]
+write_intermediate_files = no
+intermediate_output_path = ./debug_output/

--- a/investment_tree/__init__.py
+++ b/investment_tree/__init__.py
@@ -7,6 +7,6 @@ Created on Sat Jun  7 13:58:15 2025
 """
 
 
-from .builder import build_tree
+from .builder import build_tree, explode_horizontal_tree_submassa
 from .enrichment_text import enrich_text
 from .enrichment_values import enrich_values

--- a/investment_tree/builder.py
+++ b/investment_tree/builder.py
@@ -159,7 +159,7 @@ def build_tree(funds, portfolios):
     cols_common = ['dtposicao', 'cnpjfundo', 'nome', 'equity_stake', 'valor_calc',
                   'isin', 'NEW_TIPO', 'fNUMERACA.DESCRICAO', 'fNUMERACA.TIPO_ATIVO',
                   'fEMISSOR.NOME_EMISSOR', 'NEW_NOME_ATIVO', 'NEW_GESTOR',
-                  'NEW_GESTOR_WORD_CLOUD', 'rentab', 'caracteristica']
+                  'NEW_GESTOR_WORD_CLOUD', 'rentab', 'caracteristica', 'coupom', 'indexador']
 
     funds = funds[funds['valor_serie'] == 0][['cnpj'] + cols_common].copy()
 

--- a/investment_tree/builder.py
+++ b/investment_tree/builder.py
@@ -172,3 +172,75 @@ def build_tree(funds, portfolios):
     portfolios['cnpj'] = ''
 
     return build_tree_horizontal(portfolios.copy(), funds)
+
+
+def explode_horizontal_tree_submassa(tree_horzt_sub, port_submassa):
+    """
+    Propagates submassa attribution down the horizontal investment tree by
+    matching each level's ``isin`` (``isin``, ``isin_nivel_1``, ...) against
+    ``port_submassa`` and copying the submassa columns
+    (``COD_SUBMASSA``, ``SUBMASSA``, ``pct_submassa_isin_cnpb``, ``CODCART``)
+    onto the matched rows.
+
+    Rows whose submassa cannot be resolved at any level fall back to
+    ``COD_SUBMASSA = '1'`` / ``SUBMASSA = 'BSPS'`` and a participation of
+    ``1.0``.
+
+    Parameters
+    ----------
+    tree_horzt_sub : pandas.DataFrame
+        Horizontal tree restricted to (cnpb, dtposicao) pairs covered by
+        ``port_submassa``.
+    port_submassa : pandas.DataFrame
+        Submassa-tagged portfolios DataFrame with composition columns already
+        computed (see ``compute_composition_portfolio_submassa``).
+
+    Returns
+    -------
+    pandas.DataFrame
+        ``tree_horzt_sub`` enriched with the submassa columns above.
+    """
+    cols_port_submassa = ['dtposicao', 'CNPB', 'isin', 'CODCART',
+                          'COD_SUBMASSA', 'SUBMASSA', 'pct_submassa_isin_cnpb']
+    mask_port = (~port_submassa['isin'].isna())
+
+    tree_horzt_sub['COD_SUBMASSA'] = None
+    tree_horzt_sub['SUBMASSA'] = None
+    tree_horzt_sub['pct_submassa_isin_cnpb'] = 1.0
+    tree_horzt_sub['CODCART'] = None
+
+    max_depth = tree_horzt_sub['nivel'].max()
+
+    #max_depth != max_depth pega o caso float('nan'), 
+    # pois que NaN eh o único valor que nao eh igual a si mesmo.
+    if max_depth is None or max_depth != max_depth:
+        return tree_horzt_sub
+
+    for i in range(0, max_depth + 1):
+        suffix = '' if i == 0 else f'_nivel_{i}'
+        isin_col = f"isin{suffix}"
+
+        tree_horzt_sub = tree_horzt_sub.merge(
+            port_submassa[mask_port][cols_port_submassa],
+            left_on=['dtposicao', 'cnpb', isin_col],
+            right_on=['dtposicao', 'CNPB', 'isin'],
+            how='left',
+            suffixes=('', f"_{suffix}"),
+            indicator=True,
+        )
+
+        mask_merge = (tree_horzt_sub['_merge'] == 'both')
+
+        tree_horzt_sub.loc[mask_merge, 'COD_SUBMASSA'] = tree_horzt_sub[f"COD_SUBMASSA_{suffix}"]
+        tree_horzt_sub.loc[mask_merge, 'SUBMASSA'] = tree_horzt_sub[f"SUBMASSA_{suffix}"]
+        tree_horzt_sub.loc[mask_merge, 'pct_submassa_isin_cnpb'] = tree_horzt_sub[f"pct_submassa_isin_cnpb_{suffix}"]
+        tree_horzt_sub.loc[mask_merge, 'CODCART'] = tree_horzt_sub[f"CODCART_{suffix}"]
+
+        tree_horzt_sub.drop(columns=['_merge'], inplace=True)
+
+    tree_horzt_sub['pct_submassa_isin_cnpb'] = tree_horzt_sub['pct_submassa_isin_cnpb'].astype(float).fillna(1.0)
+    mask_bsps = (tree_horzt_sub['SUBMASSA'].isna())
+    tree_horzt_sub.loc[mask_bsps, 'COD_SUBMASSA'] = '1'
+    tree_horzt_sub.loc[mask_bsps, 'SUBMASSA'] = 'BSPS'
+
+    return tree_horzt_sub

--- a/investment_tree/enrichment_text.py
+++ b/investment_tree/enrichment_text.py
@@ -82,7 +82,7 @@ def enrich_text(tree_horzt):
 
     final_cols_base = [
         'NEW_TIPO', 'NEW_NOME_ATIVO', 'NEW_GESTOR_WORD_CLOUD',
-        'fEMISSOR.NOME_EMISSOR', 'fNUMERACA.TIPO_ATIVO', 'fNUMERACA.DESCRICAO'
+        'fEMISSOR.NOME_EMISSOR', 'fNUMERACA.TIPO_ATIVO', 'fNUMERACA.DESCRICAO', 'coupom', 'indexador', 'caracteristica'
     ]
     for col_base in final_cols_base:
         create_column_based_on_levels(tree_horzt, f"{col_base}_FINAL", col_base, max_depth)

--- a/pipeline_orchestration.py
+++ b/pipeline_orchestration.py
@@ -633,7 +633,6 @@ def save_pipeline_results(
     destination_file_format: str,
 ) -> None:
     with log_timing('finish', 'save_final_files'):
-        print('')
         filtrd_cols = _filter_columns('columns.carteiras', portfolios.columns)
         save_df(portfolios[filtrd_cols], destination_path / 'carteiras', destination_file_format)
 

--- a/pipeline_orchestration.py
+++ b/pipeline_orchestration.py
@@ -31,7 +31,12 @@ from returns import (
     compute_returns_from_puposicao,
     validate_unique_puposicao
     )
-from investment_tree import build_tree, enrich_text, enrich_values
+from investment_tree import (
+    build_tree,
+    enrich_text,
+    enrich_values,
+    explode_horizontal_tree_submassa,
+)
 from reporting import assign_governance_struct_keys
 import util as utl
 import data_access as dta
@@ -400,35 +405,6 @@ def compute_metrics(funds, portfolios, types_series):
         metrics.compute(portfolios, funds, types_series, group_keys_port)
 
 
-def extract_portfolio_submassa(debug_cfg, cad_submassa, portfolios):
-    with log_timing('submassa', 'extract_portfolio_submassa'):
-        mask = portfolios['codcart'].isin(cad_submassa['CODCART'])
-
-        port_submassa = portfolios.loc[mask].merge(
-            cad_submassa,
-            left_on='codcart',
-            right_on='CODCART',
-            how='left',
-        )
-
-    debug_save(port_submassa, 'submassa-carterias', debug_cfg, 'submassa', 'debug_save_portfolio_submassa')
-
-    return [portfolios.loc[~mask], port_submassa]
-
-
-def compute_composition_portfolio_submassa(debug_cfg, port_submassa):
-    with log_timing('submassa', 'compute_composition_portfolio_submassa'):
-        port_submassa['total_submassa_isin_cnpb'] = (
-            port_submassa.groupby(['dtposicao', 'CNPB', 'isin'])['valor_calc'].transform('sum')
-        )
-
-        port_submassa['pct_submassa_isin_cnpb'] = (
-            port_submassa['valor_calc'] / port_submassa['total_submassa_isin_cnpb']
-        )
-
-    debug_save(port_submassa, 'submassa-carterias-composicao', debug_cfg, 'submassa', 'debug_save_portfolio_submassa_composition')
-
-
 def validate_fund_graph_is_acyclic(funds):
     """
     Validates that the fund-to-fund relationships form a Directed Acyclic Graph (DAG).
@@ -488,57 +464,47 @@ def build_horizontal_tree(debug_cfg, funds, portfolios, port_submassa):
 
         tree_horzt_submassa = tree_horzt[mask].copy()
 
-    debug_save(tree_horzt_submassa, 'submassa-arvore', debug_cfg, 'tree', 'debug_save_tree_submassa')
+    debug_save(tree_horzt_submassa, 'submassa-arvore', debug_cfg,
+               'tree', 'debug_save_tree_submassa')
 
-    return tree_horzt.loc[~mask], tree_horzt_submassa
+    with log_timing('tree', 'explode_horizontal_tree_submassa'):
+        tree_horzt_submassa = explode_horizontal_tree_submassa(
+            tree_horzt_submassa, port_submassa
+        )
 
-#PASSAR EXPLODE SUBMASSA para tree/tree_operations como eh com carteira_operations
-def explode_horizontal_tree_submassa(debug_cfg, tree_horzt_sub, port_submassa):
-    with log_timing('tree', 'build_tree_submassa'):
-        cols_port_submassa = ['dtposicao', 'CNPB', 'isin', 'CODCART',
-                              'COD_SUBMASSA', 'SUBMASSA', 'pct_submassa_isin_cnpb']
-        mask_port = (~port_submassa['isin'].isna())
+    debug_save(tree_horzt_submassa, 'submassa-arvore-pct_part', debug_cfg,
+               'tree', 'debug_save_tree_submassa_pct_part')
 
-        tree_horzt_sub['COD_SUBMASSA'] = None
-        tree_horzt_sub['SUBMASSA'] = None
-        tree_horzt_sub['pct_submassa_isin_cnpb'] = 1.0
-        tree_horzt_sub['CODCART'] = None
+    tree_horzt = pd.concat(
+        [tree_horzt.loc[~mask], tree_horzt_submassa], ignore_index=True
+    )
+    #Preenche CODCART com vazio para as demais partes do codigo que passam a usar essa coluna
+    #para agregacoes
+    tree_horzt['CODCART'] = tree_horzt['CODCART'].fillna('')
+    tree_horzt['SUBMASSA'] = tree_horzt['SUBMASSA'].fillna('')
 
-        max_depth = tree_horzt_sub['nivel'].max()
+    return tree_horzt
 
-        if pd.isna(max_depth):
-            return tree_horzt_sub
 
-        for i in range(0, max_depth + 1):
-            suffix = '' if i == 0 else f'_nivel_{i}'
-            isin_col = f"isin{suffix}"
+def process_portfolio_submassa(portfolios, cad_submassa, debug_cfg):
+    with log_timing('submassa', 'extract_portfolio_submassa'):
+        portfolios, port_submassa = crt.extract_portfolio_submassa(
+            cad_submassa, portfolios
+        )
+    debug_save(port_submassa, 'submassa-carteiras', debug_cfg,
+               'submassa', 'debug_save_portfolio_submassa')
 
-            tree_horzt_sub = tree_horzt_sub.merge(
-                port_submassa[mask_port][cols_port_submassa],
-                left_on=['dtposicao', 'cnpb', isin_col],
-                right_on=['dtposicao', 'CNPB', 'isin'],
-                how='left',
-                suffixes=('', f"_{suffix}"),
-                indicator=True,
-            )
+    with log_timing('submassa', 'compute_composition_portfolio_submassa'):
+        crt.compute_composition_portfolio_submassa(port_submassa)
+    debug_save(port_submassa, 'submassa-carteiras-composicao', debug_cfg,
+               'submassa', 'debug_save_portfolio_submassa_composition')
 
-            mask_merge = (tree_horzt_sub['_merge'] == 'both')
+    with log_timing('submassa', 'forward_fill_submassa_pct'):
+        port_submassa = crt.forward_fill_submassa_pct(port_submassa, portfolios)
+    debug_save(port_submassa, 'submassa-carteiras-ffill', debug_cfg,
+               'submassa', 'debug_save_portfolio_submassa_ffill')
 
-            tree_horzt_sub.loc[mask_merge, 'COD_SUBMASSA'] = tree_horzt_sub[f"COD_SUBMASSA_{suffix}"]
-            tree_horzt_sub.loc[mask_merge, 'SUBMASSA'] = tree_horzt_sub[f"SUBMASSA_{suffix}"]
-            tree_horzt_sub.loc[mask_merge, 'pct_submassa_isin_cnpb'] = tree_horzt_sub[f"pct_submassa_isin_cnpb_{suffix}"]
-            tree_horzt_sub.loc[mask_merge, 'CODCART'] = tree_horzt_sub[f"CODCART_{suffix}"]
-
-            tree_horzt_sub.drop(columns=['_merge'], inplace=True)
-
-    tree_horzt_sub['pct_submassa_isin_cnpb'] = tree_horzt_sub['pct_submassa_isin_cnpb'].astype(float).fillna(1.0)
-    mask_bsps = (tree_horzt_sub['SUBMASSA'].isna())
-    tree_horzt_sub.loc[mask_bsps, 'COD_SUBMASSA'] = '1'
-    tree_horzt_sub.loc[mask_bsps, 'SUBMASSA'] = 'BSPS'
-
-    debug_save(tree_horzt_sub, 'submassa-arvore-pct_part', debug_cfg, 'tree', 'debug_save_tree_submassa_pct_part')
-
-    return tree_horzt_sub
+    return portfolios, port_submassa
 
 
 def enrich_horizontal_tree(tree_horzt, governance_struct):
@@ -690,16 +656,11 @@ def run_pipeline():
     assign_returns(funds, ['cnpj'], 'fundos')
     assign_returns(portfolios, ['codcart', 'cnpb'], 'carteiras')
 
-    portfolios, port_submassa = extract_portfolio_submassa(debug_cfg, db_aux['dcadsubmassa'], portfolios)
-    compute_composition_portfolio_submassa(debug_cfg, port_submassa)
+    portfolios, port_submassa = process_portfolio_submassa(
+        portfolios, db_aux['dcadsubmassa'], debug_cfg
+    )
 
-    tree_hrztl, tree_hrztl_sub = build_horizontal_tree(debug_cfg, funds, portfolios, port_submassa)
-    tree_hrztl_sub = explode_horizontal_tree_submassa(debug_cfg, tree_hrztl_sub, port_submassa)
-    tree_hrztl = pd.concat([tree_hrztl, tree_hrztl_sub], ignore_index=True)
-    #Preenche CODCART com vazio para as demais partes do codigo que passam a usar essa coluna
-    #para agregacoes
-    tree_hrztl['CODCART'] = tree_hrztl['CODCART'].fillna('')
-    tree_hrztl['SUBMASSA'] = tree_hrztl['SUBMASSA'].fillna('')
+    tree_hrztl = build_horizontal_tree(debug_cfg, funds, portfolios, port_submassa)
     enrich_horizontal_tree(tree_hrztl, db_aux['governance_struct'])
 
     adjust_rentab = compute_plan_returns_adjust(debug_cfg, tree_hrztl,

--- a/pipeline_orchestration.py
+++ b/pipeline_orchestration.py
@@ -10,6 +10,7 @@ Created on Fri May 30 11:33:22 2025
 from datetime import datetime
 from pathlib import Path
 from typing import Iterable
+import fnmatch
 import re
 import multiprocessing
 from concurrent.futures import ProcessPoolExecutor
@@ -499,10 +500,10 @@ def process_portfolio_submassa(portfolios, cad_submassa, debug_cfg):
     debug_save(port_submassa, 'submassa-carteiras-composicao', debug_cfg,
                'submassa', 'debug_save_portfolio_submassa_composition')
 
-    with log_timing('submassa', 'forward_fill_submassa_pct'):
-        port_submassa = crt.forward_fill_submassa_pct(port_submassa, portfolios)
-    debug_save(port_submassa, 'submassa-carteiras-ffill', debug_cfg,
-               'submassa', 'debug_save_portfolio_submassa_ffill')
+    # with log_timing('submassa', 'forward_fill_submassa_pct'):
+    #     port_submassa = crt.forward_fill_submassa_pct(port_submassa, portfolios)
+    # debug_save(port_submassa, 'submassa-carteiras-ffill', debug_cfg,
+    #            'submassa', 'debug_save_portfolio_submassa_ffill')
 
     return portfolios, port_submassa
 
@@ -596,6 +597,56 @@ def assign_adjustments(tree_hrztl, adjust_rentab):
     return tree_hrztl
 
 
+def _columns_patterns_from_df(columns: Iterable[str]) -> list[str]:
+    _nivel_col_re = re.compile(r'^(.*)_nivel_\d+$')
+    seen: set[str] = set()
+    out: list[str] = []
+    for col in columns:
+        m = _nivel_col_re.match(col)
+        pat = f'{m.group(1)}_nivel_*' if m else col
+        if pat not in seen:
+            seen.add(pat)
+            out.append(pat)
+    return out
+
+
+def _filter_columns(sys_data_key: str, df_columns: Iterable[str]) -> list[str]:
+    all_columns = list(df_columns)
+
+    dta.create_if_not_exists(sys_data_key, {'columns': _columns_patterns_from_df(all_columns)})
+
+    selectors = dta.read(sys_data_key)['columns']
+    glob_matched = {
+        col
+        for col in all_columns
+        for sel in selectors
+        if '*' in sel and fnmatch.fnmatchcase(col, sel)
+    }
+    return [col for col in all_columns if col in glob_matched or col in selectors]
+
+
+def save_pipeline_results(
+    portfolios: pd.DataFrame,
+    funds: pd.DataFrame,
+    tree_hrztl: pd.DataFrame,
+    destination_path: Path,
+    destination_file_format: str,
+) -> None:
+    with log_timing('finish', 'save_final_files'):
+        print('')
+        filtrd_cols = _filter_columns('columns.carteiras', portfolios.columns)
+        save_df(portfolios[filtrd_cols], destination_path / 'carteiras', destination_file_format)
+
+        filtrd_cols = _filter_columns('columns.fundos', funds.columns)
+        save_df(funds[filtrd_cols], destination_path / 'fundos', destination_file_format)
+    
+        filtrd_cols = _filter_columns('columns.arvore_carteiras', tree_hrztl.columns)
+        save_df(tree_hrztl[filtrd_cols], destination_path / 'arvore_carteiras', destination_file_format)
+
+        filtrd_cols = _filter_columns('columns.arvore_carteiras_rentab', tree_hrztl.columns)
+        save_df(tree_hrztl[filtrd_cols], destination_path / 'arvore_carteiras_rentab', destination_file_format)
+
+
 def run_pipeline():
     (
         xml_source_path,
@@ -669,10 +720,9 @@ def run_pipeline():
 
     tree_hrztl = assign_adjustments(tree_hrztl, adjust_rentab)
 
-    with log_timing('finish', 'save_final_files'):
-        save_df(portfolios, destination_path / 'carteiras', destination_file_format)
-        save_df(funds,      destination_path / 'fundos',    destination_file_format)
-        save_df(tree_hrztl, destination_path / 'arvore_carteiras', destination_file_format)
+    save_pipeline_results(
+        portfolios, funds, tree_hrztl, destination_path, destination_file_format
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## O que foi feito

Resolve #44

O percentual de rateio de submassa (`pct_submassa_isin_cnpb`) era calculado apenas para os dias com posição no XML, deixando os dias intermediários sem informação. Nesses dias, a base de dados ficava sem informações sobre a submassa.

## Alterações

**`carteiras_operations.py`**
- Movidas `extract_portfolio_submassa`, `compute_composition_portfolio_submassa` de `pipeline_orchestration.py` para de `carteira_operations.py`
- Adicionada `forward_fill_submassa_pct` (nova) em `carteira_operations.py`
- `forward_fill_submassa_pct` expande `port_submassa` para todas as datas do CNPB presentes em `portfolios` e propaga `pct_submassa_isin_cnpb` para frente dentro de cada grupo `(CNPB, isin, CODCART, COD_SUBMASSA)`

**`investment_tree/builder.py`**
- Adicionada `explode_horizontal_tree_submassa`, movida de `pipeline_orchestration.py`
- Removido `import pandas` — substituído `pd.isna(max_depth)` por checagem nativa
  `max_depth is None or max_depth != max_depth`

**`investment_tree/__init__.py`**
- Reexportada `explode_horizontal_tree_submassa`

**`pipeline_orchestration.py`**
- Removidas as funções movidas para os módulos de domínio
- Criadas as orquestradoras `process_portfolio_submassa` e atualizada  `build_horizontal_tree` para encapsular explode + concat + fillna
- `log_timing` e `debug_save` concentrados exclusivamente na orquestração

## Ponto em aberto

Ativos comprados no meio do mês não têm histórico anterior para propagar e permanecem `NaN`. Logo e caem no fallback BSPS. Tratamento a definir.